### PR TITLE
fix: unambigious project builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ mkdocs-mermaid2-plugin = "^0.6.0"
 schemasheets = "^0.1.14"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.extras]
 docs = ["linkml", "mkdocs-material"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-from setuptools import setup
-
-setup(
-    name='omni-schema',
-    version='0.0.1'
-)


### PR DESCRIPTION
In the current setup package builds were specified twice: 
1. in `pyproject.toml` as:
```
[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```
2. in `setup.py`

In addition versions in `setup.py` (0.0.1) and `pyproject.toml` (0.1.0) were not aligned. As a result omni-schema could not be installed e.g. via
`poetry add git+https://github.com/omnibenchmark/omni-schema.git`. I think because of ambigious specification how. I think we should only use the `pyproject.toml` file to specify package builds, as suggested in this PR.  